### PR TITLE
Updated errors for finding lib directories particularly for `rtabmap_ros`…

### DIFF
--- a/point_cloud_perception/launch/3d_depth_mapping_rtab.launch.py
+++ b/point_cloud_perception/launch/3d_depth_mapping_rtab.launch.py
@@ -82,7 +82,7 @@ def generate_launch_description():
         # SLAM mode:
         Node(
             condition=UnlessCondition(localization),
-            package='rtabmap_ros', executable='rtabmap', output='screen',
+            package='rtabmap_slam', executable='rtabmap', output='screen',
             parameters=[parameters],
             remappings=remappings,
             arguments=['-d']), # This will delete the previous database (~/.ros/rtabmap.db)
@@ -90,14 +90,14 @@ def generate_launch_description():
         # Localization mode:
         Node(
             condition=IfCondition(localization),
-            package='rtabmap_ros', executable='rtabmap', output='screen',
+            package='rtabmap_slam', executable='rtabmap', output='screen',
             parameters=[parameters,
               {'Mem/IncrementalMemory':'False',
                'Mem/InitWMWithAllNodes':'True'}],
             remappings=remappings),
 
         Node(
-            package='rtabmap_ros', executable='rtabmapviz', output='screen',
+            package='rtabmap_viz', executable='rtabmap_viz', output='screen',
             parameters=[parameters],
             remappings=remappings),
     ])


### PR DESCRIPTION
This merge request updates the file generate_launch_description() with the following changes:


```
@@ -82,22 +82,22 @@ def generate_launch_description():
        # SLAM mode:
        Node(
            condition=UnlessCondition(localization),
-            package='rtabmap_slam', executable='rtabmap', output='screen',
+            package='rtabmap_ros', executable='rtabmap', output='screen',
            parameters=[parameters],
            remappings=remappings,
            arguments=['-d']), # This will delete the previous database (~/.ros/rtabmap.db)

        # Localization mode:
        Node(
            condition=IfCondition(localization),
-            package='rtabmap_slam', executable='rtabmap', output='screen',
+            package='rtabmap_ros', executable='rtabmap', output='screen',
            parameters=[parameters,
              {'Mem/IncrementalMemory':'False',
               'Mem/InitWMWithAllNodes':'True'}],
            remappings=remappings),

        Node(
-            package='rtabmap_viz', executable='rtabmap_viz', output='screen',
+            package='rtabmap_ros', executable='rtabmapviz', output='screen',
            parameters=[parameters],
            remappings=remappings),
    ])
```
The changes involve updating the package and executable names in the Node declarations. In the previous version, the package names were `rtabmap_slam` and `rtabmap_viz`, while the updated version uses `rtabmap_ros` and `rtabmapviz` respectively. This update aligns the code with the correct package naming convention.

Please review the changes and merge them if they are acceptable.